### PR TITLE
adds node-opcua to the mobile-clean-install uninstall list

### DIFF
--- a/scripts/mobile-clean-install.sh
+++ b/scripts/mobile-clean-install.sh
@@ -9,7 +9,7 @@ for i in `ls ./`; do
   echo $i
   cd $i
   npm ci --omit=dev
-  npm uninstall --omit=dev --no-save @ffmpeg-installer/ffmpeg fsevents
+  npm uninstall --omit=dev --no-save @ffmpeg-installer/ffmpeg fsevents node-opcua
   cd ..
 done
 


### PR DESCRIPTION
I was uninstalling it manually each time (because it contains a binary that app store connect rejects) and realized I could just add it to this list 📈 