### PR TITLE
Wire up in-progress virtualizerRecordingData arguments

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -1768,8 +1768,15 @@
 
         this.startVirtualizerRecording = function(callback) {
             spatialObject.messageCallBacks.startVirtualizerRecording = function (msgContent) {
-                if (callback && typeof msgContent.virtualizerRecordingError !== 'undefined') {
-                    callback(msgContent.virtualizerRecordingError);
+                if (callback && typeof msgContent.virtualizerRecordingData !== 'undefined') {
+                    const {
+                        error,
+                        baseUrl,
+                        recordingId,
+                        deviceId,
+                        orientation,
+                    } = msgContent.virtualizerRecordingData;
+                    callback(error, baseUrl, recordingId, deviceId, orientation);
                 }
             };
 


### PR DESCRIPTION
General idea here is that all the callbacks from recording should have the same large format with errors, recording ids, etc. that the Stop callback gets. This adds them to the in-progress callback provided to Start

https://github.com/dataTimeSpace/vuforia-spatial-toolbox-ios-swift/pull/40
https://github.com/dataTimeSpace/pop-up-onboarding-addon/pull/52
https://github.com/dataTimeSpace/vuforia-spatial-edge-server/pull/42
https://github.com/dataTimeSpace/vuforia-spatial-toolbox-userinterface/pull/119
