### PR TITLE
[2/2] Adds createdAt to ObjectModel and Node, in addition to Frame; helper function for setting it

### DIFF
--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -39,7 +39,8 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
 
         await utilities.createFrameFolder(object.name, frame.name, dirname, frame.location);
 
-        var newFrame = new Frame(frame.objectId, frameKey);
+        const createdAt = frame.createdAt || Date.now();
+        const newFrame = new Frame(frame.objectId, frameKey, createdAt);
         newFrame.name = frame.name;
         newFrame.visualization = frame.visualization;
         newFrame.ar = frame.ar;
@@ -55,8 +56,6 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
         newFrame.src = frame.src;
         newFrame.width = frame.width;
         newFrame.height = frame.height;
-        // only set the created if it doesn't exist yet
-        newFrame.createdAt = frame.createdAt || Date.now();
 
         // give default values for this node type to each node's public data, if not already assigned
         for (let key in newFrame.nodes) {
@@ -91,7 +90,7 @@ const generateFrameOnObject = function (objectKey, frameType, relativeMatrix, ca
     }
 
     let frameKey = objectKey + frameType + utilities.uuidTime();
-    let newFrame = new Frame(objectKey, frameKey);
+    let newFrame = new Frame(objectKey, frameKey, Date.now());
     newFrame.name = frameType;
     newFrame.location = 'global';
     newFrame.src = frameType;
@@ -181,7 +180,8 @@ const copyFrame = function(objectID, frameID, body, callback) {
         var newName = frame.src + utilities.uuidTime();
         var newFrameKey = objectID + newName;
 
-        var newFrame = new Frame(frame.objectId, newFrameKey);
+        const createdAt = frame.createdAt || Date.now();
+        const newFrame = new Frame(frame.objectId, newFrameKey, createdAt);
         newFrame.name = newName;
         newFrame.visualization = frame.visualization;
         // deep clone ar by value, not reference, otherwise posting new position for one might affect the other
@@ -260,7 +260,8 @@ const updateFrame = function(objectID, frameID, body, callback) {
         // Copy over all properties of frame
         Object.assign(object.frames[frameID], frame);
 
-        let newFrame = new Frame(frame.objectId, frame.uuid);
+        const createdAt = frame.createdAt || Date.now();
+        let newFrame = new Frame(frame.objectId, frame.uuid, createdAt);
         newFrame.setFromJson(frame);
         object.frames[frameID] = newFrame;
 

--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -39,8 +39,7 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
 
         await utilities.createFrameFolder(object.name, frame.name, dirname, frame.location);
 
-        const createdAt = frame.createdAt || Date.now();
-        const newFrame = new Frame(frame.objectId, frameKey, createdAt);
+        const newFrame = new Frame(frame.objectId, frameKey, frame.createdAt);
         newFrame.name = frame.name;
         newFrame.visualization = frame.visualization;
         newFrame.ar = frame.ar;
@@ -90,7 +89,7 @@ const generateFrameOnObject = function (objectKey, frameType, relativeMatrix, ca
     }
 
     let frameKey = objectKey + frameType + utilities.uuidTime();
-    let newFrame = new Frame(objectKey, frameKey, Date.now());
+    let newFrame = new Frame(objectKey, frameKey);
     newFrame.name = frameType;
     newFrame.location = 'global';
     newFrame.src = frameType;
@@ -180,8 +179,7 @@ const copyFrame = function(objectID, frameID, body, callback) {
         var newName = frame.src + utilities.uuidTime();
         var newFrameKey = objectID + newName;
 
-        const createdAt = frame.createdAt || Date.now();
-        const newFrame = new Frame(frame.objectId, newFrameKey, createdAt);
+        const newFrame = new Frame(frame.objectId, newFrameKey, frame.createdAt);
         newFrame.name = newName;
         newFrame.visualization = frame.visualization;
         // deep clone ar by value, not reference, otherwise posting new position for one might affect the other
@@ -260,8 +258,7 @@ const updateFrame = function(objectID, frameID, body, callback) {
         // Copy over all properties of frame
         Object.assign(object.frames[frameID], frame);
 
-        const createdAt = frame.createdAt || Date.now();
-        let newFrame = new Frame(frame.objectId, frame.uuid, createdAt);
+        let newFrame = new Frame(frame.objectId, frame.uuid, frame.createdAt);
         newFrame.setFromJson(frame);
         object.frames[frameID] = newFrame;
 

--- a/libraries/HumanPoseObject.js
+++ b/libraries/HumanPoseObject.js
@@ -153,7 +153,7 @@ HumanPoseObject.prototype.createPoseFrames = function(poseJointSchema) {
  * @return {Frame}
  */
 HumanPoseObject.prototype.createFrame = function(jointName, shouldCreateNode) {
-    var newFrame = new Frame(this.objectId, this.getFrameKey(jointName));
+    const newFrame = new Frame(this.objectId, this.getFrameKey(jointName), Date.now());
     newFrame.name = jointName;
     newFrame.distanceScale = 2; // visible from twice as far away as usual frames
     newFrame.ar.scale = 1;
@@ -277,7 +277,8 @@ HumanPoseObject.prototype.setFromJson = function(object) {
 HumanPoseObject.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
-        let newFrame = new Frame(this.objectId, frameKey);
+        const createdAt = frames[frameKey].createdAt || Date.now();
+        let newFrame = new Frame(this.objectId, frameKey, createdAt);
         Object.assign(newFrame, frames[frameKey]);
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;

--- a/libraries/HumanPoseObject.js
+++ b/libraries/HumanPoseObject.js
@@ -55,6 +55,8 @@ function HumanPoseObject(ip, version, protocol, objectId, poseJointSchema) {
     // Parent is 'none' for any fused human object or standalone human object not currently associated with a fused one.
     // NOTE: this property can change over time and subscribers to this object should take that into account
     this.parent = 'none';
+    // Timestamp when this frame was added to the server for the first time
+    this.setCreatedAtIfUnsetOrEarlier(Date.now());
 }
 
 HumanPoseObject.prototype.getName = function(bodyId) {
@@ -153,7 +155,7 @@ HumanPoseObject.prototype.createPoseFrames = function(poseJointSchema) {
  * @return {Frame}
  */
 HumanPoseObject.prototype.createFrame = function(jointName, shouldCreateNode) {
-    const newFrame = new Frame(this.objectId, this.getFrameKey(jointName), Date.now());
+    const newFrame = new Frame(this.objectId, this.getFrameKey(jointName));
     newFrame.name = jointName;
     newFrame.distanceScale = 2; // visible from twice as far away as usual frames
     newFrame.ar.scale = 1;
@@ -247,6 +249,24 @@ HumanPoseObject.getObjectId = function(bodyId) {
     return 'humanPoseObject' + bodyId;
 };
 
+/**
+ * Conform to interface of ObjectModel
+ */
+HumanPoseObject.prototype.setCreatedAtIfUnsetOrEarlier = function(createdAt) {
+    if (createdAt == null) {
+        createdAt = Date.now(); // Use current timestamp if null or undefined
+    }
+
+    // Validate that createdAt is a proper positive number
+    if (typeof createdAt !== 'number' || !isFinite(createdAt) || createdAt <= 0) {
+        createdAt = Date.now();
+    }
+
+    // If not set yet, or new timestamp is earlier than current, set it
+    if (typeof this.createdAt !== 'number' || createdAt < this.createdAt) {
+        this.createdAt = createdAt;
+    }
+};
 
 /**
  * Conform to interface of ObjectModel
@@ -277,8 +297,7 @@ HumanPoseObject.prototype.setFromJson = function(object) {
 HumanPoseObject.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
-        const createdAt = frames[frameKey].createdAt || Date.now();
-        let newFrame = new Frame(this.objectId, frameKey, createdAt);
+        let newFrame = new Frame(this.objectId, frameKey, frames[frameKey].createdAt);
         Object.assign(newFrame, frames[frameKey]);
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -455,7 +455,7 @@ exports.setTool = function (object, tool, newTool, dirName) {
                     }
                 }
                 if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                    objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
+                    objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid, Date.now());
                     objects[objectID].frames[frameUuid].name = tool;
                 }
                 //define the tool that is used with this frame
@@ -485,7 +485,7 @@ exports.addNode = function (object, tool, node, type, position) {
         utilities.createFolder(object); // todo may need to `await` this
 
         // create a new anchor object
-        objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID);
+        objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID, Date.now());
         objects[objectID].port = serverPort;
         objects[objectID].name = object;
         objects[objectID].isAnchor = true;
@@ -518,7 +518,7 @@ exports.addNode = function (object, tool, node, type, position) {
             objects[objectID].name = object;
 
             if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
+                objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid, Date.now());
                 utilities.createFrameFolder(object, tool, dirnameO, 'local'); // todo maybe await
             } else {
                 utilities.createFrameFolder(object, tool, dirnameO, objects[objectID].frames[frameUuid].location); // todo maybe await
@@ -682,7 +682,7 @@ exports.generateFrame = function (objectName, frameType, relativeMatrix) {
     }
 
     let frameKey = objectID + frameType + utilities.uuidTime();
-    let newFrame = new Frame(objectID, frameKey);
+    let newFrame = new Frame(objectID, frameKey, Date.now());
     newFrame.name = frameType;
     newFrame.location = 'global';
     newFrame.src = frameType;

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -455,7 +455,7 @@ exports.setTool = function (object, tool, newTool, dirName) {
                     }
                 }
                 if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                    objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid, Date.now());
+                    objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
                     objects[objectID].frames[frameUuid].name = tool;
                 }
                 //define the tool that is used with this frame
@@ -485,7 +485,7 @@ exports.addNode = function (object, tool, node, type, position) {
         utilities.createFolder(object); // todo may need to `await` this
 
         // create a new anchor object
-        objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID, Date.now());
+        objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID);
         objects[objectID].port = serverPort;
         objects[objectID].name = object;
         objects[objectID].isAnchor = true;
@@ -518,7 +518,7 @@ exports.addNode = function (object, tool, node, type, position) {
             objects[objectID].name = object;
 
             if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid, Date.now());
+                objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
                 utilities.createFrameFolder(object, tool, dirnameO, 'local'); // todo maybe await
             } else {
                 utilities.createFrameFolder(object, tool, dirnameO, objects[objectID].frames[frameUuid].location); // todo maybe await
@@ -682,7 +682,7 @@ exports.generateFrame = function (objectName, frameType, relativeMatrix) {
     }
 
     let frameKey = objectID + frameType + utilities.uuidTime();
-    let newFrame = new Frame(objectID, frameKey, Date.now());
+    let newFrame = new Frame(objectID, frameKey);
     newFrame.name = frameType;
     newFrame.location = 'global';
     newFrame.src = frameType;

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -188,7 +188,7 @@ exports.printFolder = async function printFolder(objects, objectsPath, _debug, o
 
             // populate the data for each frame template on the frontend, using data from the object json structure
             for (var frameKey in objects[thisObjectKey].frames) {
-                const createdAt = objects[thisObjectKey].frames[frameKey].createdAt || Date.now();
+                const createdAt = objects[thisObjectKey].frames[frameKey].createdAt;
                 newObject[thisObjectKey].frames[frameKey] = new Frame(thisObjectKey, frameKey, createdAt);
                 newObject[thisObjectKey].frames[frameKey].name = objects[thisObjectKey].frames[frameKey].name;
                 newObject[thisObjectKey].frames[frameKey].location = objects[thisObjectKey].frames[frameKey].location; // 'global' or 'local'

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -188,7 +188,8 @@ exports.printFolder = async function printFolder(objects, objectsPath, _debug, o
 
             // populate the data for each frame template on the frontend, using data from the object json structure
             for (var frameKey in objects[thisObjectKey].frames) {
-                newObject[thisObjectKey].frames[frameKey] = new Frame(thisObjectKey, frameKey);
+                const createdAt = objects[thisObjectKey].frames[frameKey].createdAt || Date.now();
+                newObject[thisObjectKey].frames[frameKey] = new Frame(thisObjectKey, frameKey, createdAt);
                 newObject[thisObjectKey].frames[frameKey].name = objects[thisObjectKey].frames[frameKey].name;
                 newObject[thisObjectKey].frames[frameKey].location = objects[thisObjectKey].frames[frameKey].location; // 'global' or 'local'
                 newObject[thisObjectKey].frames[frameKey].src = objects[thisObjectKey].frames[frameKey].src; // the frame type, e.g. 'graphUI'

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -6,10 +6,6 @@ const Node = require('./Node.js');
  * @constructor
  */
 function Frame(objectId, frameId, createdAt) {
-    if (!createdAt) {
-        console.warn('Frame was constructed without a createdAt timestamp; defaulting to Date.now()');
-    }
-
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
     this.objectId = objectId;
     // Stores its own unique ID
@@ -67,8 +63,29 @@ function Frame(objectId, frameId, createdAt) {
     // "Pinned" frames are by default loaded and visible with the object they belong to. Unpinned must be asked for.
     this.pinned = true;
     // Timestamp when this frame was added to the server for the first time
-    this.createdAt = createdAt || Date.now();
+    this.setCreatedAtIfUnsetOrEarlier(createdAt); // defaults to Date.now()
 }
+
+/**
+ * Sets `createdAt` if it hasn't been set, or if the new value is a valid earlier timestamp.
+ * If the input is undefined/null, it uses Date.now().
+ * @param {*} createdAt - candidate timestamp
+ */
+Frame.prototype.setCreatedAtIfUnsetOrEarlier = function(createdAt) {
+    if (createdAt == null) {
+        createdAt = Date.now(); // Use current timestamp if null or undefined
+    }
+
+    // Validate that createdAt is a proper finite non-negative number
+    if (typeof createdAt !== 'number' || !isFinite(createdAt) || createdAt < 0) {
+        createdAt = Date.now();
+    }
+
+    // If not set yet, or new timestamp is earlier than current, set it
+    if (typeof this.createdAt !== 'number' || createdAt < this.createdAt) {
+        this.createdAt = createdAt;
+    }
+};
 
 /**
  * Should be called before deleting the frame in order to properly destroy it
@@ -91,6 +108,7 @@ Frame.prototype.deconstruct = function() {
  */
 Frame.prototype.setFromJson = function(frame) {
     Object.assign(this, frame);
+    this.setCreatedAtIfUnsetOrEarlier(frame.createdAt);
     this.setNodesFromJson(frame.nodes);
 };
 
@@ -106,6 +124,7 @@ Frame.prototype.setNodesFromJson = function(nodes) {
         let type = nodes[nodeKey].type;
         let newNode = new Node(name, type, this.objectId, this.uuid, nodeKey);
         Object.assign(newNode, nodes[nodeKey]);
+        newNode.setCreatedAtIfUnsetOrEarlier(nodes[nodeKey].createdAt);
         this.nodes[nodeKey] = newNode;
     }
 };

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -5,7 +5,11 @@ const Node = require('./Node.js');
  *
  * @constructor
  */
-function Frame(objectId, frameId) {
+function Frame(objectId, frameId, createdAt) {
+    if (!createdAt) {
+        console.warn('Frame was constructed without a createdAt timestamp; defaulting to Date.now()');
+    }
+
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
     this.objectId = objectId;
     // Stores its own unique ID
@@ -63,7 +67,7 @@ function Frame(objectId, frameId) {
     // "Pinned" frames are by default loaded and visible with the object they belong to. Unpinned must be asked for.
     this.pinned = true;
     // Timestamp when this frame was added to the server for the first time
-    this.createdAt = null;
+    this.createdAt = createdAt || Date.now();
 }
 
 /**

--- a/models/Node.js
+++ b/models/Node.js
@@ -7,7 +7,7 @@ const availableModules = require('../libraries/availableModules');
  *
  * @constructor
  */
-function Node(name, type, objectId, frameId, nodeId) {
+function Node(name, type, objectId, frameId, nodeId, createdAt) {
     // the name of each link. It is used in the Reality Editor to show the IO name.
     this.name = name || '';
     // the ID of the containing object.
@@ -35,6 +35,9 @@ function Node(name, type, objectId, frameId, nodeId) {
     // indicates how much calls per second is happening on this node
     this.stress = 0;
 
+    // Timestamp when this frame was added to the server for the first time
+    this.setCreatedAtIfUnsetOrEarlier(createdAt); // Defaults to Date.now()
+
     // load the publicData/privateData from the properties defined by this node type
     let nodeTypes = availableModules.getNodes();
     if (typeof nodeTypes[type] === 'undefined') {
@@ -53,6 +56,27 @@ function Node(name, type, objectId, frameId, nodeId) {
 
     this.setupProgram();
 }
+
+/**
+ * Sets `createdAt` if it hasn't been set, or if the new value is a valid earlier timestamp.
+ * If the input is undefined/null, it uses Date.now().
+ * @param {*} createdAt - candidate timestamp
+ */
+Node.prototype.setCreatedAtIfUnsetOrEarlier = function(createdAt) {
+    if (createdAt == null) {
+        createdAt = Date.now(); // Use current timestamp if null or undefined
+    }
+
+    // Validate that createdAt is a proper positive number
+    if (typeof createdAt !== 'number' || !isFinite(createdAt) || createdAt <= 0) {
+        createdAt = Date.now();
+    }
+
+    // If not set yet, or new timestamp is earlier than current, set it
+    if (typeof this.createdAt !== 'number' || createdAt < this.createdAt) {
+        this.createdAt = createdAt;
+    }
+};
 
 /**
  * Triggers the exports.setup function defined in the add-on for this node type

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -9,8 +9,13 @@ const Frame = require('./Frame.js'); // needs reference to Frame constructor
  * @param {string} version - Version number of server, currently 3.1.0 or 3.2.0
  * @param {string} protocol - Protocol of object, one of R0, R1, or R2 (current)
  * @param {string} objectId - Stores its own UUID
+ * @param {number} createdAt - Timestamp when the object was first created on the server, e.g. Date.now()
  */
-function ObjectModel(ip, version, protocol, objectId) {
+function ObjectModel(ip, version, protocol, objectId, createdAt) {
+    if (!createdAt) {
+        console.warn('Object was constructed without a createdAt timestamp; defaulting to Date.now()');
+    }
+
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
     this.objectId = objectId;
     // The name for the object used for interfaces.
@@ -60,9 +65,10 @@ function ObjectModel(ip, version, protocol, objectId) {
     this.isWorldObject = false; // a bit redundant with this.type, but good for backwards compatibility
     this.isAnchor = false;
     this.type = 'object'; // or: 'world' or 'human' or 'avatar' etc...
-    this.timestamp = null; // timestamp optionally stores when the object was first created
     this.gaussianSplatRequestId = null; // Optional id for in-progress request to GS server
     this.renderMode = null; // Can be set to 'mesh' or 'ai' to synchronize render mode across clients
+    // Timestamp when this object was added to the server for the first time
+    this.createdAt = createdAt || Date.now();
 }
 
 /**
@@ -86,6 +92,9 @@ ObjectModel.prototype.deconstruct = function() {
  */
 ObjectModel.prototype.setFromJson = function(object) {
     Object.assign(this, object);
+    // if (!object.createdAt) {
+    //     this.createdAt = Date.now(); // add `createdAt` to objects that don't have it
+    // }
     this.setFramesFromJson(object.frames);
 };
 
@@ -97,11 +106,12 @@ ObjectModel.prototype.setFromJson = function(object) {
 ObjectModel.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
-        let newFrame = new Frame(this.objectId, frameKey);
+        const createdAt = frames[frameKey].createdAt || Date.now(); // add `createdAt` to frames that don't have it
+        let newFrame = new Frame(this.objectId, frameKey, createdAt);
         Object.assign(newFrame, frames[frameKey]);
-        if (!frames[frameKey].created) {
-            newFrame.createdAt = Date.now(); // add `createdAt` to frames that don't have it
-        }
+        // if (!frames[frameKey].createdAt) {
+        //     newFrame.createdAt = Date.now(); 
+        // }
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;
     }

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -9,13 +9,9 @@ const Frame = require('./Frame.js'); // needs reference to Frame constructor
  * @param {string} version - Version number of server, currently 3.1.0 or 3.2.0
  * @param {string} protocol - Protocol of object, one of R0, R1, or R2 (current)
  * @param {string} objectId - Stores its own UUID
- * @param {number} createdAt - Timestamp when the object was first created on the server, e.g. Date.now()
+ * @param {number|undefined} createdAt - Timestamp when the object was first created on the server, e.g. Date.now() or earlier
  */
 function ObjectModel(ip, version, protocol, objectId, createdAt) {
-    if (!createdAt) {
-        console.warn('Object was constructed without a createdAt timestamp; defaulting to Date.now()');
-    }
-
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
     this.objectId = objectId;
     // The name for the object used for interfaces.
@@ -67,9 +63,30 @@ function ObjectModel(ip, version, protocol, objectId, createdAt) {
     this.type = 'object'; // or: 'world' or 'human' or 'avatar' etc...
     this.gaussianSplatRequestId = null; // Optional id for in-progress request to GS server
     this.renderMode = null; // Can be set to 'mesh' or 'ai' to synchronize render mode across clients
-    // Timestamp when this object was added to the server for the first time
-    this.createdAt = createdAt || Date.now();
+    // Timestamp when this frame was added to the server for the first time
+    this.setCreatedAtIfUnsetOrEarlier(createdAt); // Defaults to Date.now()
 }
+
+/**
+ * Sets `createdAt` if it hasn't been set, or if the new value is a valid earlier timestamp.
+ * If the input is undefined/null, it uses Date.now().
+ * @param {*} createdAt - candidate timestamp
+ */
+ObjectModel.prototype.setCreatedAtIfUnsetOrEarlier = function(createdAt) {
+    if (createdAt == null) {
+        createdAt = Date.now(); // Use current timestamp if null or undefined
+    }
+
+    // Validate that createdAt is a proper positive number
+    if (typeof createdAt !== 'number' || !isFinite(createdAt) || createdAt <= 0) {
+        createdAt = Date.now();
+    }
+
+    // If not set yet, or new timestamp is earlier than current, set it
+    if (typeof this.createdAt !== 'number' || createdAt < this.createdAt) {
+        this.createdAt = createdAt;
+    }
+};
 
 /**
  * Should be called before deleting the object in order to properly destroy it
@@ -92,9 +109,7 @@ ObjectModel.prototype.deconstruct = function() {
  */
 ObjectModel.prototype.setFromJson = function(object) {
     Object.assign(this, object);
-    // if (!object.createdAt) {
-    //     this.createdAt = Date.now(); // add `createdAt` to objects that don't have it
-    // }
+    this.setCreatedAtIfUnsetOrEarlier(object.createdAt);
     this.setFramesFromJson(object.frames);
 };
 
@@ -106,13 +121,8 @@ ObjectModel.prototype.setFromJson = function(object) {
 ObjectModel.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
-        const createdAt = frames[frameKey].createdAt || Date.now(); // add `createdAt` to frames that don't have it
-        let newFrame = new Frame(this.objectId, frameKey, createdAt);
-        Object.assign(newFrame, frames[frameKey]);
-        // if (!frames[frameKey].createdAt) {
-        //     newFrame.createdAt = Date.now(); 
-        // }
-        newFrame.setNodesFromJson(frames[frameKey].nodes);
+        let newFrame = new Frame(this.objectId, frameKey, frames[frameKey].createdAt);
+        newFrame.setFromJson(frames[frameKey]);
         this.frames[frameKey] = newFrame;
     }
 };

--- a/server.js
+++ b/server.js
@@ -589,6 +589,28 @@ nodeUtilities.setup(objects, sceneGraph, knownObjects, socketArray, globalVariab
 
     await startSystem();
 
+    const logCreatedAt = (objs) => {
+        const simplified = {};
+
+        for (const [objectId, objectData] of Object.entries(objs)) {
+            const { createdAt, frames } = objectData;
+            simplified[objectId] = {
+                createdAt,
+                frames: {}
+            };
+
+            if (frames && typeof frames === 'object') {
+                for (const [frameId, frameData] of Object.entries(frames)) {
+                    simplified[objectId].frames[frameId] = {
+                        createdAt: frameData.createdAt
+                    };
+                }
+            }
+        }
+        console.log(simplified);
+    }
+    logCreatedAt(objects);
+
     // Get the directory names of all available sources for the 3D-UI
     if (!isLightweightMobile) {
         hardwareInterfaceLoader = new AddonFolderLoader(hardwareInterfacePaths);
@@ -661,7 +683,7 @@ async function loadObjects() {
 
         if (tempFolderName !== null) {
             // fill objects with objects named by the folders in objects
-            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol, tempFolderName);
+            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol, tempFolderName, Date.now());
             objects[tempFolderName].port = serverPort;
             objects[tempFolderName].name = objectFolderList[i];
 
@@ -677,6 +699,7 @@ async function loadObjects() {
             try {
                 const objectJsonText = await fsProm.readFile(pathJoinRooted(objectsPath, objectFolderList[i], identityFolderName, 'object.json'), 'utf8');
                 objects[tempFolderName] = JSON.parse(objectJsonText);
+                // objects[tempFolderName].setFromJson(JSON.parse(objectJsonText));
                 const obj = objects[tempFolderName];
                 obj.ip = services.ip; // ip.address();
 
@@ -708,7 +731,8 @@ async function loadObjects() {
                 let newObj = new ObjectModel(obj.ip,
                     obj.version,
                     obj.protocol,
-                    obj.objectId);
+                    obj.objectId,
+                    obj.createdAt || Date.now());
                 newObj.setFromJson(obj);
                 objects[tempFolderName] = newObj;
             } catch (e) {
@@ -787,7 +811,7 @@ async function loadWorldObject() {
 
     // create a new world object
     let thisWorldObjectId = (isLightweightMobile || isStandaloneMobile) ? worldObjectName : (worldObjectName + utilities.uuidTime());
-    worldObject = new ObjectModel(services.ip, version, protocol, thisWorldObjectId);
+    worldObject = new ObjectModel(services.ip, version, protocol, thisWorldObjectId, Date.now());
     worldObject.port = serverPort;
     worldObject.name = worldObjectName;
     worldObject.isWorldObject = true;
@@ -797,7 +821,8 @@ async function loadWorldObject() {
     if (globalVariables.saveToDisk) {
         try {
             const contents = await fsProm.readFile(jsonFilePath, 'utf8');
-            worldObject = JSON.parse(contents);
+            // worldObject = JSON.parse(contents);
+            worldObject.setFromJson(JSON.parse(contents));
         } catch (e) {
             console.error('No saved data for world object on server: ' + services.ip, e);
         }
@@ -834,7 +859,6 @@ async function loadAnchor(anchorName) {
         await mkdirIfNotExists(identityPath, {recursive: true});
     }
 
-
     // try to read previously saved data to overwrite the default anchor object
     if (globalVariables.saveToDisk) {
         try {
@@ -842,7 +866,7 @@ async function loadAnchor(anchorName) {
             let anchor = JSON.parse(contents);
             anchorUuid = anchor.objectId;
             if (anchorUuid) {
-                objects[anchorUuid] = anchor;
+                objects[anchorUuid].setFromJson(anchor);
             }
             return;
         } catch (e) {
@@ -851,7 +875,8 @@ async function loadAnchor(anchorName) {
     }
 
     // create a new anchor object
-    objects[anchorUuid] = new ObjectModel(services.ip, version, protocol, anchorUuid);
+    const createdAt = (objects[anchorUuid] && objects[anchorUuid].createdAt) || Date.now();
+    objects[anchorUuid] = new ObjectModel(services.ip, version, protocol, anchorUuid, createdAt);
     objects[anchorUuid].port = serverPort;
     objects[anchorUuid].name = anchorName;
 
@@ -863,6 +888,8 @@ async function loadAnchor(anchorName) {
         0, 0, 0, 1
     ];
     objects[anchorUuid].tcs = 0;
+
+    // objects[anchorUuid].createdAt = objects[anchorUuid].createdAt || Date.now();
 
     if (globalVariables.saveToDisk) {
         try {
@@ -2439,7 +2466,7 @@ function objectWebServer() {
                             // special constructor for HumanPoseObject that also creates a frame for each joint
                             objects[objectId] = new HumanPoseObject(services.ip, version, protocol, objectId, JSON.parse(req.body.poseJointSchema));
                         } else {
-                            objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId);
+                            objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId, Date.now());
                         }
 
                         objects[objectId].name = req.body.name;
@@ -2451,6 +2478,8 @@ function objectWebServer() {
                         if (typeof req.body.worldId !== 'undefined') {
                             objects[objectId].worldId = req.body.worldId;
                         }
+
+                        objects[objectId].createdAt = objects[objectId].createdAt || Date.now();
 
                         await utilities.writeObjectToFile(objects, objectId, globalVariables.saveToDisk);
                         utilities.writeObject(objectLookup, req.body.name, objectId);
@@ -2472,7 +2501,7 @@ function objectWebServer() {
                                     return;
                                 }
 
-                                objects[objectId].frames[toolId] = new Frame(objectId, toolId);
+                                objects[objectId].frames[toolId] = new Frame(objectId, toolId, Date.now());
                                 objects[objectId].frames[toolId].name = toolName;
                                 await utilities.writeObjectToFile(objects, objectId, globalVariables.saveToDisk);
 
@@ -2536,7 +2565,7 @@ function objectWebServer() {
                             return;
                         }
 
-                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame(objectKey, objectKey + req.body.frame);
+                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame(objectKey, objectKey + req.body.frame, Date.now());
                         objects[objectKey].frames[objectKey + req.body.frame].name = req.body.frame;
                         await utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
                         // sceneGraph.addObjectAndChildren(tempFolderName, objects[tempFolderName]);
@@ -3286,14 +3315,16 @@ async function createObjectFromTarget(folderVar) {
 
     let targetUniqueId = await utilities.getTargetIdFromTargetDat(pathJoinRooted(objectsPath, folderVar, identityFolderName, 'target'));
 
-    objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId);
+    const createdAt = (objects[objectId] && objects[objectId].createdAt) || Date.now();
+    objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId, createdAt);
     objects[objectId].port = serverPort;
     objects[objectId].name = folderVar;
     objects[objectId].targetSize = objectSizeXML;
 
     try {
         const contents = await fsProm.readFile(pathJoinRooted(objFolder, identityFolderName, 'object.json'), 'utf8');
-        objects[objectId] = JSON.parse(contents);
+        // objects[objectId] = JSON.parse(contents);
+        objects[objectId].setFromJson(JSON.parse(contents));
         // objects[objectId].objectId = objectId;
         objects[objectId].ip = services.ip; //ip.address();
     } catch (e) {
@@ -3304,7 +3335,6 @@ async function createObjectFromTarget(folderVar) {
     if (objectId.indexOf(worldObjectName) > -1) { // TODO: implement a more robust way to tell if it's a world object
         objects[objectId].isWorldObject = true;
         objects[objectId].type = 'world';
-        objects[objectId].timestamp = Date.now();
     }
 
     objects[objectId].targetId = targetUniqueId;

--- a/server.js
+++ b/server.js
@@ -589,28 +589,6 @@ nodeUtilities.setup(objects, sceneGraph, knownObjects, socketArray, globalVariab
 
     await startSystem();
 
-    const logCreatedAt = (objs) => {
-        const simplified = {};
-
-        for (const [objectId, objectData] of Object.entries(objs)) {
-            const { createdAt, frames } = objectData;
-            simplified[objectId] = {
-                createdAt,
-                frames: {}
-            };
-
-            if (frames && typeof frames === 'object') {
-                for (const [frameId, frameData] of Object.entries(frames)) {
-                    simplified[objectId].frames[frameId] = {
-                        createdAt: frameData.createdAt
-                    };
-                }
-            }
-        }
-        console.log(simplified);
-    }
-    logCreatedAt(objects);
-
     // Get the directory names of all available sources for the 3D-UI
     if (!isLightweightMobile) {
         hardwareInterfaceLoader = new AddonFolderLoader(hardwareInterfacePaths);
@@ -683,7 +661,7 @@ async function loadObjects() {
 
         if (tempFolderName !== null) {
             // fill objects with objects named by the folders in objects
-            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol, tempFolderName, Date.now());
+            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol, tempFolderName);
             objects[tempFolderName].port = serverPort;
             objects[tempFolderName].name = objectFolderList[i];
 
@@ -699,7 +677,6 @@ async function loadObjects() {
             try {
                 const objectJsonText = await fsProm.readFile(pathJoinRooted(objectsPath, objectFolderList[i], identityFolderName, 'object.json'), 'utf8');
                 objects[tempFolderName] = JSON.parse(objectJsonText);
-                // objects[tempFolderName].setFromJson(JSON.parse(objectJsonText));
                 const obj = objects[tempFolderName];
                 obj.ip = services.ip; // ip.address();
 
@@ -731,8 +708,7 @@ async function loadObjects() {
                 let newObj = new ObjectModel(obj.ip,
                     obj.version,
                     obj.protocol,
-                    obj.objectId,
-                    obj.createdAt || Date.now());
+                    obj.objectId);
                 newObj.setFromJson(obj);
                 objects[tempFolderName] = newObj;
             } catch (e) {
@@ -811,7 +787,7 @@ async function loadWorldObject() {
 
     // create a new world object
     let thisWorldObjectId = (isLightweightMobile || isStandaloneMobile) ? worldObjectName : (worldObjectName + utilities.uuidTime());
-    worldObject = new ObjectModel(services.ip, version, protocol, thisWorldObjectId, Date.now());
+    worldObject = new ObjectModel(services.ip, version, protocol, thisWorldObjectId);
     worldObject.port = serverPort;
     worldObject.name = worldObjectName;
     worldObject.isWorldObject = true;
@@ -821,7 +797,6 @@ async function loadWorldObject() {
     if (globalVariables.saveToDisk) {
         try {
             const contents = await fsProm.readFile(jsonFilePath, 'utf8');
-            // worldObject = JSON.parse(contents);
             worldObject.setFromJson(JSON.parse(contents));
         } catch (e) {
             console.error('No saved data for world object on server: ' + services.ip, e);
@@ -866,6 +841,7 @@ async function loadAnchor(anchorName) {
             let anchor = JSON.parse(contents);
             anchorUuid = anchor.objectId;
             if (anchorUuid) {
+                objects[anchorUuid] = new ObjectModel(services.ip, version, protocol, anchorUuid);
                 objects[anchorUuid].setFromJson(anchor);
             }
             return;
@@ -875,7 +851,7 @@ async function loadAnchor(anchorName) {
     }
 
     // create a new anchor object
-    const createdAt = (objects[anchorUuid] && objects[anchorUuid].createdAt) || Date.now();
+    const createdAt = (objects[anchorUuid] && objects[anchorUuid].createdAt);
     objects[anchorUuid] = new ObjectModel(services.ip, version, protocol, anchorUuid, createdAt);
     objects[anchorUuid].port = serverPort;
     objects[anchorUuid].name = anchorName;
@@ -888,8 +864,6 @@ async function loadAnchor(anchorName) {
         0, 0, 0, 1
     ];
     objects[anchorUuid].tcs = 0;
-
-    // objects[anchorUuid].createdAt = objects[anchorUuid].createdAt || Date.now();
 
     if (globalVariables.saveToDisk) {
         try {
@@ -2466,7 +2440,7 @@ function objectWebServer() {
                             // special constructor for HumanPoseObject that also creates a frame for each joint
                             objects[objectId] = new HumanPoseObject(services.ip, version, protocol, objectId, JSON.parse(req.body.poseJointSchema));
                         } else {
-                            objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId, Date.now());
+                            objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId);
                         }
 
                         objects[objectId].name = req.body.name;
@@ -2478,8 +2452,6 @@ function objectWebServer() {
                         if (typeof req.body.worldId !== 'undefined') {
                             objects[objectId].worldId = req.body.worldId;
                         }
-
-                        objects[objectId].createdAt = objects[objectId].createdAt || Date.now();
 
                         await utilities.writeObjectToFile(objects, objectId, globalVariables.saveToDisk);
                         utilities.writeObject(objectLookup, req.body.name, objectId);
@@ -2501,7 +2473,7 @@ function objectWebServer() {
                                     return;
                                 }
 
-                                objects[objectId].frames[toolId] = new Frame(objectId, toolId, Date.now());
+                                objects[objectId].frames[toolId] = new Frame(objectId, toolId);
                                 objects[objectId].frames[toolId].name = toolName;
                                 await utilities.writeObjectToFile(objects, objectId, globalVariables.saveToDisk);
 
@@ -2565,7 +2537,7 @@ function objectWebServer() {
                             return;
                         }
 
-                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame(objectKey, objectKey + req.body.frame, Date.now());
+                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame(objectKey, objectKey + req.body.frame);
                         objects[objectKey].frames[objectKey + req.body.frame].name = req.body.frame;
                         await utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
                         // sceneGraph.addObjectAndChildren(tempFolderName, objects[tempFolderName]);
@@ -3315,7 +3287,7 @@ async function createObjectFromTarget(folderVar) {
 
     let targetUniqueId = await utilities.getTargetIdFromTargetDat(pathJoinRooted(objectsPath, folderVar, identityFolderName, 'target'));
 
-    const createdAt = (objects[objectId] && objects[objectId].createdAt) || Date.now();
+    const createdAt = (objects[objectId] && objects[objectId].createdAt);
     objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId, createdAt);
     objects[objectId].port = serverPort;
     objects[objectId].name = folderVar;
@@ -3323,7 +3295,6 @@ async function createObjectFromTarget(folderVar) {
 
     try {
         const contents = await fsProm.readFile(pathJoinRooted(objFolder, identityFolderName, 'object.json'), 'utf8');
-        // objects[objectId] = JSON.parse(contents);
         objects[objectId].setFromJson(JSON.parse(contents));
         // objects[objectId].objectId = objectId;
         objects[objectId].ip = services.ip; //ip.address();

--- a/tests/object.test.js
+++ b/tests/object.test.js
@@ -87,7 +87,7 @@ async function testObjectCreation() {
     expect(fdsaFs.targetSize).toEqual({width: 0.3, height: 0.3});
     expect(fdsaFs.isWorldObject).toBe(false);
     expect(fdsaFs.type).toBe('object');
-    expect(fdsaFs.timestamp).toBe(null);
+    expect(typeof fdsaFs.createdAt).toBe('number');
     expect(fdsaFs.port).toBe(8080);
 
     return fdsaApi;

--- a/tests/upload-target.test.js
+++ b/tests/upload-target.test.js
@@ -91,7 +91,8 @@ test('target upload to /content/:objectName', async () => {
     delete objJson.ip;
     delete objJson.port;
     delete objJson.tcs;
-    delete objJson.timestamp;
+    expect(typeof objJson.createdAt).toBe('number');
+    delete objJson.createdAt;
     expect(objJson).toEqual({
         objectId: preUploadObjJson.objectId,
         name: '_WORLD_instantScan6bK1sn5d',


### PR DESCRIPTION
Stacks on https://github.com/dataTimeSpace/vuforia-spatial-edge-server/pull/44, adds createdAt to Objects and Nodes in addition to Frames. Uses a helper function to assign Date.now() as the createdAt if undefined, or an earlier timestamp if provided, but never a later timestamp than is already stored.